### PR TITLE
Hpcc 9121

### DIFF
--- a/esp/files/templates/WUQueryWidget.html
+++ b/esp/files/templates/WUQueryWidget.html
@@ -23,6 +23,7 @@
                         <div data-dojo-type="dijit.TooltipDialog" class="toolTip">
                             <div id="${id}FilterForm" style="width:460px" data-dojo-type="dijit.form.Form">
                                 <div data-dojo-props="cols:2" data-dojo-type="dojox.layout.TableContainer">
+                                    <input id="${id}Wuid" title="WUID:" name="Wuid" colspan="2" data-dojo-props="trim: true, placeHolder:'W20130222-171723'" data-dojo-type="dijit.form.TextBox" />
                                     <input id="${id}Owner" title="Owner:" name="Owner" colspan="2" data-dojo-props="trim: true, placeHolder:'jsmi*'" data-dojo-type="dijit.form.TextBox" />
                                     <input id="${id}Jobname" title="Job&nbsp;Name:" name="Jobname" colspan="2" data-dojo-props="trim: true, placeHolder:'log_analysis_1*'" data-dojo-type="dijit.form.TextBox" />
                                     <input id="${id}ClusterTargetSelect" title="Cluster:" name="Cluster" colspan="3" data-dojo-props="trim: true, placeHolder:'r?x*'" data-dojo-type="TargetSelectWidget" />


### PR DESCRIPTION
There is an issue with quick filter. I can't seem to find why its not filtering the grid. It's adding it to the form and it works if I submit the form in the dropdown. 

 Also, with GETDFU I have a clust called "thor" but "thor" does not exist in the targetselectwidget in this page. I wanted to get this in tonight so you can see it first thing in the am and possibly save me a couple of hours of work with the quick filtering.
